### PR TITLE
readme: remove links to Google Play and Nethunter stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,7 @@ required font or color files.
 
 ## Installation
 
-Termux:Styling application can be obtained from:
-
-- [Google Play](https://play.google.com/store/apps/details?id=com.termux.styling)
-- [F-Droid](https://f-droid.org/en/packages/com.termux.styling/)
-- [Kali Nethunter Store](https://store.nethunter.com/en/packages/com.termux.styling/)
+Termux:Styling application can be obtained from [F-Droid](https://f-droid.org/en/packages/com.termux.styling/).
 
 Additionally we provide per-commit debug builds for those who want to try
 out the latest features or test their pull request. This build can be obtained


### PR DESCRIPTION
Both offer outdated builds.